### PR TITLE
Handle digits for versioning in YAML files regex

### DIFF
--- a/default.json
+++ b/default.json
@@ -52,7 +52,7 @@
       "description": "Update YAML files",
       "fileMatch": ["^.+\\.ya?ml$"],
       "matchStrings": [
-        "\\s*: \"?(?<currentValue>.+?)\"? # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s"
+        "\\s*: \"?(?<currentValue>.+?)\"? # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z\\d-]+?))?\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
Allows support for strings like `pep440` (see [documentation](https://docs.renovatebot.com/modules/versioning/#supported-versioning)).