### PR TITLE
Add regex for pre commit Python additional dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -52,7 +52,7 @@
       "description": "Update YAML files",
       "fileMatch": ["^.+\\.ya?ml$"],
       "matchStrings": [
-        "\\s*: \"?(?<currentValue>.+?)\"? # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z\\d-]+?))?\\s"
+        "\\s*: \"?(?<currentValue>.+?)\"?[[:blank:]]+#[[:blank:]]*renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z\\d-]+?))?\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },
@@ -60,7 +60,7 @@
       "description": "Update pre-commit Python additional dependencies",
       "fileMatch": ["^.pre-commit-config.yaml$"],
       "matchStrings": [
-        "\"(?<depName>[\\w-]+)(?<currentValue>.+?)\" # renovate: pre-commit-python-dependency\\s"
+        "\"(?<depName>[\\w-]+)(?<currentValue>.+?)\"[[:blank:]]+#[[:blank:]]*renovate: pre-commit-python-dependency\\s"
       ],
       "datasourceTemplate": "pypi"
     }

--- a/default.json
+++ b/default.json
@@ -55,6 +55,14 @@
         "\\s*: \"?(?<currentValue>.+?)\"? # renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: lookupName=(?<lookupName>.+?))?(?: versioning=(?<versioning>[a-z\\d-]+?))?\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "description": "Update pre-commit Python additional dependencies",
+      "fileMatch": ["^.pre-commit-config.yaml$"],
+      "matchStrings": [
+        "\"(?<depName>[\\w-]+)(?<currentValue>.+?)\" # renovate: pre-commit-python-dependency\\s"
+      ],
+      "datasourceTemplate": "pypi"
     }
   ]
 }


### PR DESCRIPTION
Add a regex to target pre-commit Python additional dependencies, in order to target things like:
```yaml
repos:
  - repo: https://github.com/PyCQA/flake8
    rev: "4.0.1"
    hooks:
      - id: flake8
        additional_dependencies:
          - "flake8-bugbear==21.9.2" # renovate: pre-commit-python-dependency
          - "flake8-simplify==0.14.2" # renovate: pre-commit-python-dependency
```