### PR TITLE
Keep default `ignorePaths` set by default config

### DIFF
--- a/default.json
+++ b/default.json
@@ -46,7 +46,6 @@
       "ignoreUnstable": false
     }
   ],
-  "ignorePaths": [],
   "regexManagers": [
     {
       "description": "Update YAML files",


### PR DESCRIPTION
Ensures that fixtures in `__fixtures__` are not considered by Renovate.