### PR TITLE
feat(config) handle `renovate` v36 breaking changes

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:base",
+    "config:recommended",
     ":automergeDigest",
     ":enablePreCommit",
     ":maintainLockFilesWeekly",
@@ -22,11 +22,11 @@
       labels: ["dev-dependencies"],
     },
     {
-      matchLanguages: ["python"],
+      matchCategories: ["python"],
       addLabels: ["python"],
     },
     {
-      matchLanguages: ["javascript"],
+      matchCategories: ["javascript"],
       addLabels: ["javascript"],
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>mkniewallner/renovate-config:default.json5", ":automergeMinor"],
-  platformAutomerge: true,
 }


### PR DESCRIPTION
Handle breaking changes in Renovate v36 (https://github.com/renovatebot/renovate/releases/tag/36.0.0). Waiting for the version to be updated in the OSS hosted version (https://docs.renovatebot.com/faq/#when-are-new-renovate-oss-releases-added-to-the-hosted-mend-renovate-app).