### PR TITLE
refactor(config): use `customManagers` instead of `regexManagers`

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -46,7 +46,7 @@
       customChangelogUrl: "https://github.com/charliermarsh/ruff",
     },
   ],
-  regexManagers: [
+  customManagers: [
     {
       customType: "regex",
       description: "Update PEP 440 Python dependencies",

--- a/tests/regexes.test.ts
+++ b/tests/regexes.test.ts
@@ -9,7 +9,7 @@ function regexMatches(target: string, patterns: string[]): boolean {
 }
 
 describe("Update PEP 440 Python dependencies", () => {
-  const regexManager = loadRenovateConfiguration()["regexManagers"][0];
+  const regexManager = loadRenovateConfiguration()["customManagers"][0];
 
   test.each([".pre-commit-config.yaml", "pyproject.toml"])(
     "find dependencies in `%s`",


### PR DESCRIPTION
`regexManagers` is deprecated: https://docs.renovatebot.com/configuration-options/#custommanagers