### PR TITLE
ci: go back to `pnpm run`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: node --run lint .
-      - run: node --run type-check
+      - run: pnpm run lint .
+      - run: pnpm run type-check
 
   tests:
     runs-on: ubuntu-24.04
@@ -43,4 +43,4 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: node --run test
+      - run: pnpm run test


### PR DESCRIPTION
Spotted this error on the CI, which exits with a status code 0, so silently failing:

```
Run node --run lint .
[error] No parser and no file path given, couldn't infer a parser.
```